### PR TITLE
Fix typo in readme instructions

### DIFF
--- a/users-and-auth/README.md
+++ b/users-and-auth/README.md
@@ -25,7 +25,7 @@ Auth0.
 Run
 
 ```
-npx convex add
+npx convex auth add
 ```
 
 to configure Convex with your Auth0 URL and application ID. Instructions at


### PR DESCRIPTION
Fixes a teeny typo, missing "auth" in `npx convex auth add`