### PR TITLE
docs: sync relational schema example with implementation

### DIFF
--- a/relational-data-modeling/README.md
+++ b/relational-data-modeling/README.md
@@ -21,7 +21,7 @@ export default defineSchema({
     author: v.string(),
     body: v.string(),
     channel: v.id("channels"),
-  }),
+  }).index("by_channel", ["channel"]),
 });
 ```
 


### PR DESCRIPTION
## Summary

Sync the `relational-data-modeling` README schema snippet with the example implementation by including the `messages.by_channel` index.

## Why

The README describes the resulting schema for the example, but the implementation defines:

```ts
messages: defineTable({
  author: v.string(),
  body: v.string(),
  channel: v.id("channels"),
}).index("by_channel", ["channel"]),
```

The example query also uses that index via `.withIndex("by_channel", ...)`, so readers copying the README schema would miss a required part of the working example.

## Tests

- `git diff --check`
- `cd relational-data-modeling && npm install --no-package-lock && npm run build`
